### PR TITLE
Create schema.sql for Book and Label

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -4,3 +4,13 @@ CREATE TABLE labels(
     color VARCHAR(255),
     PRIMARY KEY (id)
 );
+
+CREATE TABLE books(
+    id INT GENERATED ALWAYS AS IDENTITY,
+    publish_data DATE,
+    archived BOOLEAN,
+    publisher VARCHAR(255),
+    cover_state VARCHAR(255),
+    label_id INT,
+    FOREIGN KEY (label_id) REFERENCES labels(id)
+);

--- a/schema.sql
+++ b/schema.sql
@@ -1,0 +1,6 @@
+CREATE TABLE labels(
+    id INT GENERATED ALWAYS AS IDENTITY,
+    title VARCHAR(255),
+    color VARCHAR(255),
+    PRIMARY KEY (id)
+);

--- a/schema.sql
+++ b/schema.sql
@@ -11,6 +11,12 @@ CREATE TABLE books(
     archived BOOLEAN,
     publisher VARCHAR(255),
     cover_state VARCHAR(255),
-    label_id INT,
+    genre_id INT NULL,
+    author_id INT NULL,
+    source_id INT NULL,
+    label_id INT NULL,
+    FOREIGN KEY (genre_id) REFERENCES genres(id),
+    FOREIGN KEY (author_id) REFERENCES authors(id),
+    FOREIGN KEY (source_id) REFERENCES sources(id),
     FOREIGN KEY (label_id) REFERENCES labels(id)
 );


### PR DESCRIPTION
In this PR I added required sql commands to `schema.sql` file for:
- books
- labels

The association between books and genres, authors, sources, and labels is also implemented.

