### PR TITLE
Change can_be_archived method to private

### DIFF
--- a/lib/book.rb
+++ b/lib/book.rb
@@ -9,6 +9,8 @@ class Book < Item
     @cover_state = cover_state
   end
 
+  private
+
   def can_be_archived?
     return true if super
     return true if @cover_state == 'bad'

--- a/spec/book_spec.rb
+++ b/spec/book_spec.rb
@@ -42,7 +42,7 @@ describe Book do
       publish_date = Time.now.year - 15
 
       the_book = Book.new(publisher, cover_state, publish_date)
-      actual = the_book.can_be_archived?
+      actual = the_book.send(:can_be_archived?)
       expected = true
       expect(actual).to be expected
     end
@@ -53,7 +53,7 @@ describe Book do
       publish_date = Time.now.year - 5
 
       the_book = Book.new(publisher, cover_state, publish_date)
-      actual = the_book.can_be_archived?
+      actual = the_book.send(:can_be_archived?)
       expected = true
       expect(actual).to be expected
     end
@@ -64,7 +64,7 @@ describe Book do
       publish_date = Time.now.year - 5
 
       the_book = Book.new(publisher, cover_state, publish_date)
-      actual = the_book.can_be_archived?
+      actual = the_book.send(:can_be_archived?)
       expected = false
       expect(actual).to be expected
     end


### PR DESCRIPTION
In this PR, I fixed the mistake I made in past by leaving the overridden `can_be_archived?` public. Now it is private and tests are updated accordingly.

closes #33 